### PR TITLE
Apply black formatting

### DIFF
--- a/ferum_customs/custom_logic/service_report_hooks.py
+++ b/ferum_customs/custom_logic/service_report_hooks.py
@@ -38,7 +38,9 @@ def validate(doc: "ServiceReport", method: str | None = None) -> None:
         frappe.ValidationError: Если нарушены бизнес-правила.
     """
     if not doc.service_request:
-        frappe.throw(_("Не выбрана связанная заявка на обслуживание (Service Request)."))
+        frappe.throw(
+            _("Не выбрана связанная заявка на обслуживание (Service Request).")
+        )
 
     if not frappe.db.exists("Service Request", doc.service_request):
         frappe.throw(
@@ -51,9 +53,9 @@ def validate(doc: "ServiceReport", method: str | None = None) -> None:
 
     if not req_status:
         frappe.logger(__name__).error(
-            _("Не удалось получить статус для заявки '{0}', связанной с отчетом '{1}'.").format(
-                doc.service_request, doc.name
-            )
+            _(
+                "Не удалось получить статус для заявки '{0}', связанной с отчетом '{1}'."
+            ).format(doc.service_request, doc.name)
         )
         frappe.throw(
             _(
@@ -123,5 +125,7 @@ def on_submit(doc: "ServiceReport", method: str | None = None) -> None:
             exc_info=True,
         )
         frappe.throw(
-            _("Произошла ошибка при обновлении связанной заявки. Обратитесь к администратору.")
+            _(
+                "Произошла ошибка при обновлении связанной заявки. Обратитесь к администратору."
+            )
         )

--- a/ferum_customs/custom_logic/service_request_hooks.py
+++ b/ferum_customs/custom_logic/service_request_hooks.py
@@ -96,7 +96,11 @@ def get_engineers_for_object(service_object_name: str) -> List[str]:
         so_doc: "FrappeDocument" = frappe.get_doc("Service Object", service_object_name)
         engineers_table = so_doc.get("assigned_engineers") or []
         return list(
-            {entry.get("engineer") for entry in engineers_table if entry.get("engineer")}
+            {
+                entry.get("engineer")
+                for entry in engineers_table
+                if entry.get("engineer")
+            }
         )
     except frappe.DoesNotExistError:
         frappe.logger(__name__).info(


### PR DESCRIPTION
## Summary
- apply black formatting to custom logic hooks

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6846a66090208328bd6905a8f83a9528