### PR TITLE
Fix CI actions and add missing dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,15 +28,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v4
         with:
           python-version: '3.10'
 
       - name: Cache pre-commit hooks
-        uses: actions/cache@v4
+        uses: actions/cache@v3
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -59,7 +59,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3
 
       - name: Build and start Frappe Stack
         run: docker compose -f docker-compose.yml up -d --build
@@ -100,7 +100,7 @@ jobs:
 
       - name: Upload ${{ matrix.type }} test report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.type }}-test-report
           path: reports/${{ matrix.type }}-results.xml

--- a/ferum_customs/setup.py
+++ b/ferum_customs/setup.py
@@ -11,5 +11,6 @@ setup(
     zip_safe=False,
     install_requires=[
         "setuptools",
+        "frappe",
     ],
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ black
 ruff
 pytest
 requests
+frappe


### PR DESCRIPTION
## Summary
- use stable GitHub action versions in CI
- add frappe dependency to setup.py and requirements

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath: 404 Not Found: test_site does not exist)*
- `pytest` *(fails: IncorrectSitePath: 404 Not Found: test_site does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6846e7e346c88328852358da62626f74