### PR TITLE
Update CI actions and dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,31 +28,34 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install system packages
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            build-essential libmysqlclient-dev mariadb-server redis-server \
-            wkhtmltopdf curl
-          curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+            build-essential libmysqlclient-dev mariadb-server-10.6 redis-server \
+            wkhtmltopdf=0.12.5* curl
+          curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
           sudo apt-get install -y nodejs
-          sudo npm install -g yarn@1
+          sudo npm install -g yarn@1.22
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install -r requirements-dev.txt
 
       - name: Cache pre-commit hooks
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pre-commit
           key: ${{ runner.os }}-precommit-${{ hashFiles('.pre-commit-config.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-precommit-
 
-      - name: Install dependencies
-        run: pip install --upgrade pre-commit
 
       - name: Run pre-commit hooks (skip pytest)
         env:
@@ -73,19 +76,23 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt', 'dev-requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Cache bench
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.bench
           key: ${{ runner.os }}-bench-${{ hashFiles('patches.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-bench-
 
       - name: Build and start Frappe Stack
         run: docker compose -f docker-compose.yml up -d --build
@@ -137,7 +144,7 @@ jobs:
 
       - name: Upload ${{ matrix.type }} test report
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.type }}-test-report
           path: reports/${{ matrix.type }}-results.xml

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+frappe @ git+https://github.com/frappe/frappe.git@v15.21.0
+erpnext @ git+https://github.com/frappe/erpnext.git@v15.21.0
+black
+ruff
+pytest
+mypy
+pre-commit
+requests


### PR DESCRIPTION
## Summary
- upgrade reusable GitHub actions
- cache precommit, pip, bench with restore keys
- install system packages with Node 20 and yarn 1.22
- use setup-python@v5 with explicit version and install Python deps
- add requirements-dev.txt for local development

## Testing
- `pre-commit run --all-files`

------
https://chatgpt.com/codex/tasks/task_e_684711907e588328ba7d8caca0af3653