### PR TITLE
Improve test robustness

### DIFF
--- a/tests/e2e/test_site_access.py
+++ b/tests/e2e/test_site_access.py
@@ -1,4 +1,7 @@
-import requests
+import pytest
+
+# Skip test if 'requests' is not installed.
+requests = pytest.importorskip("requests")
 
 
 def test_site_index(frappe_site_container):

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,9 @@ import subprocess
 import time
 
 import pytest
-import requests
+
+# Skip the integration tests early when the 'requests' package is not available.
+requests = pytest.importorskip("requests")
 
 
 def _wait_for_site(url: str, timeout: int = 120) -> None:

--- a/tests/integration/test_container.py
+++ b/tests/integration/test_container.py
@@ -1,4 +1,7 @@
-import requests
+import pytest
+
+# Skip test if 'requests' is not installed.
+requests = pytest.importorskip("requests")
 
 
 def test_site_running(frappe_site_container):


### PR DESCRIPTION
## Summary
- skip integration tests when `requests` isn't installed

## Testing
- `pre-commit run --all-files`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68471e8b7d90832882182de7943b84e6