### PR TITLE
Remove wkhtmltopdf version pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             build-essential libmysqlclient-dev mariadb-server-10.6 redis-server \
-            wkhtmltopdf=0.12.5* curl
+            wkhtmltopdf curl
           curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
           sudo apt-get install -y nodejs
           sudo npm install -g yarn@1.22


### PR DESCRIPTION
## Summary
- remove the explicit version when installing wkhtmltopdf in the CI config

## Testing
- `pre-commit run --all-files` *(fails: pytest errors because Frappe site is missing)*
- `pytest` *(fails: IncorrectSitePath errors)*

------
https://chatgpt.com/codex/tasks/task_e_684723d76df48328be5e8746b38522a7