### PR TITLE
Использование единого файла зависимостей

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           python-version: "3.11"
           cache: "pip"
-          cache-dependency-path: requirements-dev.txt
+          cache-dependency-path: dev-requirements.txt
 
       - name: Install Python dependencies
-        run: pip install -r requirements-dev.txt
+        run: pip install -r dev-requirements.txt
 
       - name: Cache pre-commit hooks
         uses: actions/cache@v4
@@ -78,7 +78,7 @@ jobs:
           path: |
             ~/.cache/pip
             ~/.bench
-          key: ${{ runner.os }}-pip-bench-${{ hashFiles('**/requirements-dev.txt') }}
+          key: ${{ runner.os }}-pip-bench-${{ hashFiles('**/dev-requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-bench-
 
@@ -96,7 +96,7 @@ jobs:
       # --- Python dependencies -------------------------------------------
       - name: Install Python deps (requirements + bench CLI)
         run: |
-          pip install --no-cache-dir -r requirements-dev.txt  # содержит frappe + erpnext
+          pip install --no-cache-dir -r dev-requirements.txt  # содержит frappe + erpnext
           pip install --no-cache-dir frappe-bench
 
       # --- Bench init & site ---------------------------------------------

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,0 @@
-frappe~=15.21
-erpnext~=15.21
-black
-ruff
-pytest
-mypy
-pre-commit
-requests


### PR DESCRIPTION
## Summary
- use `dev-requirements.txt` as single source of requirements
- update CI to install from that file
- drop obsolete `requirements-dev.txt`

## Testing
- `pytest -q`
- ❌ `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684725b8e448832882dad22ded54f692