### PR TITLE
Remove frappe from install_requires

### DIFF
--- a/ferum_customs/setup.py
+++ b/ferum_customs/setup.py
@@ -9,9 +9,5 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     zip_safe=False,
-    install_requires=[
-        "setuptools",
-        "frappe~=15.21",
-        "erpnext~=15.21",
-    ],
+    install_requires=["setuptools"],
 )


### PR DESCRIPTION
## Summary
- remove `frappe` and `erpnext` from `install_requires`
- keep them only in dev requirements, referenced from git

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath: 404 Not Found)*
- `pytest` *(fails: IncorrectSitePath 404)*

------
https://chatgpt.com/codex/tasks/task_e_684727b6ccf4832892b1bace0b9ba161