### PR TITLE
Fix Service Project naming inconsistencies

### DIFF
--- a/ferum_customs/doctype/service_project/service_project.py
+++ b/ferum_customs/doctype/service_project/service_project.py
@@ -68,7 +68,7 @@ class ServiceProject(Document):  # Имя класса в CamelCase
             except Exception as e:
                 # Если даты не удалось распарсить, это может быть ошибкой ввода
                 frappe.logger(__name__).warning(
-                    f"Could not validate dates for ServiceProject {self.name} due to parsing error: {e}"
+                    f"Could not validate dates for Service Project {self.name} due to parsing error: {e}"
                 )
                 # Можно выбросить ошибку, если формат дат критичен на этом этапе
                 # frappe.throw(_("Некорректный формат даты начала или окончания проекта."))
@@ -86,7 +86,7 @@ class ServiceProject(Document):  # Имя класса в CamelCase
                         setattr(self, fieldname, field_value.isoformat())
                     except Exception as e:
                         frappe.logger(__name__).error(
-                            f"Error converting date field '{fieldname}' to ISO format for ServiceProject '{self.name}': {e}"
+                            f"Error converting date field '{fieldname}' to ISO format for Service Project '{self.name}': {e}"
                         )
                 # else: уже обработано not isinstance(str)
             elif isinstance(field_value, str):

--- a/ferum_customs/patches/v1_0/rename_project_to_service_project.py
+++ b/ferum_customs/patches/v1_0/rename_project_to_service_project.py
@@ -20,12 +20,12 @@ def execute():
             print("Successfully renamed 'Project' to 'Service Project'.")
         except Exception as e:
             frappe.log_error(
-                f"Error renaming DocType Project to ServiceProject: {e}", "Patch Error"
+                f"Error renaming DocType Project to Service Project: {e}", "Patch Error"
             )
             print(f"Error during rename: {e}")
         # frappe.db.commit() # Usually not needed as patches run in their own transaction.
         # Keep if there's a specific reason for intermediate commit in a more complex patch.
     elif not frappe.db.exists("DocType", "Project"):
         print("DocType 'Project' does not exist. Skipping rename.")
-    elif frappe.db.exists("DocType", "ServiceProject"):
-        print("DocType 'ServiceProject' already exists. Skipping rename.")
+    elif frappe.db.exists("DocType", "Service Project"):
+        print("DocType 'Service Project' already exists. Skipping rename.")


### PR DESCRIPTION
## Summary
- ensure log messages and patch use the DocType name "Service Project"

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath errors)*
- `pytest` *(fails: IncorrectSitePath errors)*

------
https://chatgpt.com/codex/tasks/task_e_684732091188832894637fcdefcf088d