### PR TITLE
Configure MariaDB password & bench flags

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -18,7 +18,8 @@ if ! bench --site "$SITE_NAME" ls >/dev/null 2>&1; then
     echo "[bootstrap] Creating site $SITE_NAME..."
     bench new-site "$SITE_NAME" \
         --admin-password "${ADMIN_PASSWORD:-admin}" \
-        --mariadb-root-password "${MYSQL_ROOT_PASSWORD:-root}"
+        --mariadb-root-password "${MYSQL_ROOT_PASSWORD:-root}" \
+        --no-mariadb-socket
 
     echo "[bootstrap] Installing app from $APP_PATH..."
     bench get-app "$APP_NAME" --source-path "$APP_PATH"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,4 +5,5 @@ ruff
 pytest
 mypy
 pre-commit
-requests
+requests==2.31.0
+click==8.1.7

--- a/dev_bootstrap.sh
+++ b/dev_bootstrap.sh
@@ -16,7 +16,8 @@ cd "$BENCH_DIR"
 if ! sudo -u frappe -H bench --site "$SITE_NAME" ls >/dev/null 2>&1; then
     sudo -u frappe -H bench new-site "$SITE_NAME" \
         --admin-password "${ADMIN_PASSWORD:-admin}" \
-        --mariadb-root-password "${MYSQL_ROOT_PASSWORD:-root}"
+        --mariadb-root-password "${MYSQL_ROOT_PASSWORD:-root}" \
+        --no-mariadb-socket
 fi
 
 if ! sudo -u frappe -H bench list-apps | grep -q "$APP_NAME"; then

--- a/docs/INSTALL_FULL.md
+++ b/docs/INSTALL_FULL.md
@@ -38,7 +38,7 @@ sudo systemctl start mariadb
 ```
 При необходимости задайте пароль `root` для пользователя `root`:
 ```bash
-sudo mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY 'root'; FLUSH PRIVILEGES;"
+sudo mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY 'root'; FLUSH PRIVILEGES;"
 ```
 
 ## 6. Установка wkhtmltopdf
@@ -65,7 +65,7 @@ cd ferumdub
 ## 9. Создание сайта
 ```bash
 cd frappe-bench
-bench new-site erp.ferumrus.ru
+bench new-site erp.ferumrus.ru --no-mariadb-socket
 ```
 Введите пароль root для MariaDB и задайте пароль администратора.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 black
 ruff
 pytest
-requests
+requests==2.31.0
+click==8.1.7
 frappe

--- a/setup-environment.sh
+++ b/setup-environment.sh
@@ -30,9 +30,7 @@ sudo apt-get install -y \
 
 # --- Настройка MariaDB для совместимости с Frappe Bench ---
 echo "Configuring MariaDB for Frappe Bench..."
-sudo mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD:-root}';"
-sudo mysql -u root -e "UPDATE mysql.user SET plugin = 'mysql_native_password' WHERE User = 'root';"
-sudo mysql -u root -e "FLUSH PRIVILEGES;"
+sudo mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY '${MYSQL_ROOT_PASSWORD:-root}'; FLUSH PRIVILEGES;"
 
 # --- Установка и настройка Frappe Bench ---
 # Install bench CLI if not present
@@ -51,7 +49,8 @@ cd "$BENCH_DIR"
 if ! sudo -u frappe -H bench --site "$SITE_NAME" ls >/dev/null 2>&1; then
     sudo -u frappe -H bench new-site "$SITE_NAME" \
         --admin-password "${ADMIN_PASSWORD:-admin}" \
-        --mariadb-root-password "${MYSQL_ROOT_PASSWORD:-root}"
+        --mariadb-root-password "${MYSQL_ROOT_PASSWORD:-root}" \
+        --no-mariadb-socket
 fi
 
 # Install local app if not installed


### PR DESCRIPTION
## Summary
- configure MariaDB root with mysql_native_password
- set `--no-mariadb-socket` when creating a site
- pin click and requests versions
- document updated commands

## Testing
- `pre-commit run --all-files`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684737eb86b483288b75b8e81f884a96