### PR TITLE
Update bench usage for CI and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,12 +102,9 @@ jobs:
       # --- Bench init & site ---------------------------------------------
       - name: Init bench & create test_site
         run: |
-          bench init frappe-bench --frappe-branch version-15
+          sudo bench init frappe-bench --frappe-branch version-15
           cd frappe-bench
-          bench new-site test_site \
-                --admin-password "$ADMIN_PASSWORD" \
-                --mariadb-root-password "$MYSQL_ROOT_PASSWORD" \
-                --no-mariadb-socket
+          sudo bench new-site test_site
           bench get-app erpnext --branch version-15
           bench --site test_site install-app erpnext
           bench set-config allow_tests true

--- a/README.md
+++ b/README.md
@@ -56,12 +56,9 @@ Bench запустится автоматически и будет доступ
 ```bash
 pip install frappe-bench
 export CI=true  # позволяет запускать bench под root
-bench init frappe-bench --frappe-branch version-15
+sudo bench init frappe-bench --frappe-branch version-15
 cd frappe-bench
-bench new-site test_site \
-  --admin-password=admin \
-  --mariadb-root-password=root \
-  --no-mariadb-socket
+sudo bench new-site test_site
 bench get-app erpnext --branch version-15
 bench --site test_site install-app erpnext
 bench set-config allow_tests true

--- a/docs/INSTALL_FULL.md
+++ b/docs/INSTALL_FULL.md
@@ -65,7 +65,7 @@ cd ferumdub
 ## 9. Создание сайта
 ```bash
 cd frappe-bench
-bench new-site erp.ferumrus.ru --no-mariadb-socket
+sudo bench new-site erp.ferumrus.ru
 ```
 Введите пароль root для MariaDB и задайте пароль администратора.
 


### PR DESCRIPTION
## Summary
- remove password options and keep socket auth
- run bench with sudo in CI and docs

## Testing
- `pre-commit run --all-files` *(fails: pre-commit not fully configured)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68475df719c08328816734ace46087c0