### PR TITLE
Add bench path verification in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN chmod +x /bootstrap.sh /entrypoint.sh
 USER frappe
 WORKDIR /home/frappe
 
-RUN pip install --user frappe-bench \
-    && ~/.local/bin/bench init frappe-bench --frappe-branch version-15 --skip-assets
-
+RUN pip install --user frappe-bench
 ENV PATH="/home/frappe/.local/bin:$PATH"
+RUN bench --version
+RUN bench init frappe-bench --frappe-branch version-15 --skip-assets
+
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- ensure `bench` is on PATH in Dockerfile
- verify bench availability during build

## Testing
- `pytest`
- `pre-commit` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684760b8d8b08328bc51af5db458b818