### PR TITLE
Modify entrypoint for automatic site creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,12 +20,13 @@ services:
       - mariadb
       - redis
     environment:
-      SITE_NAME: your-site-name
-      DB_ROOT_USER: root
-      MYSQL_ROOT_PASSWORD: root
-      ADMIN_PASSWORD: admin
-      INSTALL_APPS: erpnext,ferum_customs
+      - SITE_NAME=test_site
+      - ADMIN_PWD=admin
+      - DB_ROOT_PWD=
+    volumes:
+      - sites_volume:/home/frappe/frappe-bench/sites
 
 volumes:
   mariadb:
   redis:
+  sites_volume:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,17 +2,29 @@
 set -e
 
 BENCH_FOLDER="${BENCH_FOLDER:-frappe-bench}"
+SITE_NAME="${SITE_NAME:-test_site}"
+ADMIN_PWD="${ADMIN_PWD:-admin}"
+DB_ROOT_PWD="${DB_ROOT_PWD:-""}"
 
 if [ ! -d "$BENCH_FOLDER" ]; then
     /bootstrap.sh
 fi
 
 cd "$BENCH_FOLDER"
-bench use dev.localhost
+
+if [ ! -f "/home/frappe/frappe-bench/sites/${SITE_NAME}/site_config.json" ]; then
+    echo ">> Creating Frappe site ${SITE_NAME}"
+    bench new-site "$SITE_NAME" \
+         --admin-password "$ADMIN_PWD" \
+         --mariadb-root-password "$DB_ROOT_PWD" \
+         --install-app erpnext
+fi
+
+bench use "$SITE_NAME"
 
 if [[ "$1" == "pytest" ]]; then
     shift
-    bench --site "${SITE_NAME:-dev.localhost}" run-tests --app ferum_customs \
+    bench --site "$SITE_NAME" run-tests --app ferum_customs \
         --junit-xml="${JUNIT_XML:-/app/reports/bench-results.xml}" "$@"
 else
     exec "$@"


### PR DESCRIPTION
## Summary
- add environment defaults to entrypoint
- create site if missing and switch bench to it
- add persistent sites volume and env vars in compose

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath: test_site does not exist)*
- `pytest tests/unit`
- `pytest` *(fails: IncorrectSitePath: test_site does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6847622909808328aa2c01107a810b62