### PR TITLE
Fix yarn registry and pin Ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
   #  ЗАДАНИЕ 1: ПРОВЕРКА КАЧЕСТВА КОДА (ЛИНТЕРЫ)
   # =======================================================
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10 # Ограничение времени выполнения
 
     steps:
@@ -75,7 +75,7 @@ jobs:
   tests:
     # Запускается только после успешного завершения 'lint'
     needs: lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 30
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ WORKDIR /home/frappe
 RUN pip install --user frappe-bench
 ENV PATH="/home/frappe/.local/bin:$PATH"
 RUN bench --version
+RUN yarn config set registry https://registry.npmjs.org \
+ && yarn config set network-timeout 600000
 RUN bench init frappe-bench --frappe-branch version-15 --skip-assets
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- set Yarn registry and timeout in Dockerfile
- pin workflow runners to ubuntu-22.04

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath)*
- `pytest -q` *(fails: IncorrectSitePath)*

------
https://chatgpt.com/codex/tasks/task_e_6847661578288328a275a9bc10916c30