### PR TITLE
Add Doctype fixtures for custom modules

### DIFF
--- a/ferum_customs/fixtures/service_object.json
+++ b/ferum_customs/fixtures/service_object.json
@@ -1,7 +1,59 @@
 [
   {
-    "doctype": "Service Object",
-    "object_name": "Демо Объект",
-    "service_project": "Демо Проект"
+    "doctype": "DocType",
+    "name": "Service Object",
+    "module": "Ferum Customs",
+    "engine": "InnoDB",
+    "track_changes": 1,
+    "title_field": "object_name",
+    "fields": [
+      {
+        "fieldname": "object_name",
+        "label": "Название объекта",
+        "fieldtype": "Data",
+        "reqd": 1,
+        "in_list_view": 1,
+        "unique": 1
+      },
+      {
+        "fieldname": "customer",
+        "label": "Клиент",
+        "fieldtype": "Link",
+        "options": "Customer",
+        "in_list_view": 1
+      },
+      {
+        "fieldname": "location",
+        "label": "Расположение",
+        "fieldtype": "Data"
+      },
+      {
+        "fieldname": "description",
+        "label": "Описание",
+        "fieldtype": "Text"
+      },
+      {
+        "fieldname": "status",
+        "label": "Статус",
+        "fieldtype": "Select",
+        "options": "Active\nInactive\nUnder Maintenance",
+        "default": "Active",
+        "in_list_view": 1
+      }
+    ],
+    "permissions": [
+      {
+        "role": "Проектный менеджер",
+        "read": 1,
+        "write": 1,
+        "create": 1,
+        "delete": 1
+      },
+      {
+        "role": "Инженер",
+        "read": 1
+      }
+    ],
+    "custom": 1
   }
 ]

--- a/ferum_customs/fixtures/service_project.json
+++ b/ferum_customs/fixtures/service_project.json
@@ -1,6 +1,79 @@
 [
   {
-    "doctype": "Service Project",
-    "project_name": "Демо Проект"
+    "doctype": "DocType",
+    "name": "Service Project",
+    "module": "Ferum Customs",
+    "engine": "InnoDB",
+    "track_changes": 1,
+    "title_field": "project_name",
+    "fields": [
+      {
+        "fieldname": "project_name",
+        "label": "Название проекта",
+        "fieldtype": "Data",
+        "reqd": 1,
+        "in_list_view": 1,
+        "unique": 1
+      },
+      {
+        "fieldname": "customer",
+        "label": "Клиент",
+        "fieldtype": "Link",
+        "options": "Customer",
+        "in_list_view": 1
+      },
+      {
+        "fieldname": "status",
+        "label": "Статус",
+        "fieldtype": "Select",
+        "options": "Open\nIn Progress\nCompleted\nCancelled",
+        "default": "Open",
+        "in_list_view": 1
+      },
+      {
+        "fieldname": "start_date",
+        "label": "Дата начала",
+        "fieldtype": "Date"
+      },
+      {
+        "fieldname": "end_date",
+        "label": "Дата окончания",
+        "fieldtype": "Date"
+      },
+      {
+        "fieldname": "description",
+        "label": "Описание",
+        "fieldtype": "Text"
+      },
+      {
+        "fieldname": "column_break_1",
+        "fieldtype": "Column Break"
+      },
+      {
+        "fieldname": "project_object_items_section",
+        "fieldtype": "Section Break",
+        "label": "Объекты обслуживания в проекте"
+      },
+      {
+        "fieldname": "project_object_items",
+        "label": "Project Object Items",
+        "fieldtype": "Table",
+        "options": "ProjectObjectItem"
+      }
+    ],
+    "permissions": [
+      {
+        "role": "Проектный менеджер",
+        "read": 1,
+        "write": 1,
+        "create": 1,
+        "delete": 1
+      },
+      {
+        "role": "Инженер",
+        "read": 1
+      }
+    ],
+    "custom": 1
   }
 ]

--- a/ferum_customs/fixtures/service_request.json
+++ b/ferum_customs/fixtures/service_request.json
@@ -1,8 +1,91 @@
 [
   {
-    "doctype": "Service Request",
-    "service_object": "Демо Объект",
-    "subject": "Первая заявка",
-    "status": "Открыта"
+    "doctype": "DocType",
+    "name": "Service Request",
+    "module": "Ferum Customs",
+    "engine": "InnoDB",
+    "issingle": 0,
+    "is_submittable": 1,
+    "show_name_in_global_search": 1,
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "track_changes": 1,
+    "track_seen": 1,
+    "track_views": 1,
+    "allow_rename": 1,
+    "naming_series": "SR-.YYYY.-.#####",
+    "title_field": "subject",
+    "has_web_view": 1,
+    "web_view_title_field": "subject",
+    "web_view_search_fields": [
+      "subject",
+      "status"
+    ],
+    "workflow_name": "Service Request Workflow",
+    "fields": [
+      {
+        "fieldname": "request_datetime",
+        "label": "Дата и время заявки",
+        "fieldtype": "Datetime",
+        "default": "Now",
+        "read_only": 1,
+        "in_list_view": 1
+      },
+      {
+        "fieldname": "completed_on",
+        "label": "Дата выполнения",
+        "fieldtype": "Datetime",
+        "read_only": 1,
+        "no_copy": 1
+      },
+      {
+        "fieldname": "planned_start_datetime",
+        "label": "План. начало работ",
+        "fieldtype": "Datetime"
+      },
+      {
+        "fieldname": "planned_end_datetime",
+        "label": "План. окончание работ",
+        "fieldtype": "Datetime"
+      },
+      {
+        "fieldname": "actual_start_datetime",
+        "label": "Факт. начало работ",
+        "fieldtype": "Datetime",
+        "read_only": 1,
+        "no_copy": 1
+      },
+      {
+        "fieldname": "actual_end_datetime",
+        "label": "Факт. окончание работ",
+        "fieldtype": "Datetime",
+        "read_only": 1,
+        "no_copy": 1
+      },
+      {
+        "fieldname": "duration_hours",
+        "label": "Длительность (часы)",
+        "fieldtype": "Float",
+        "precision": 2,
+        "read_only": 1,
+        "no_copy": 1
+      },
+      {
+        "fieldname": "subject",
+        "label": "Тема",
+        "fieldtype": "Data",
+        "reqd": 1,
+        "in_list_view": 1
+      },
+      {
+        "fieldname": "status",
+        "label": "Статус",
+        "fieldtype": "Data",
+        "read_only": 1,
+        "in_list_view": 1,
+        "no_copy": 1
+      }
+    ],
+    "custom": 1
   }
 ]

--- a/ferum_customs/hooks.py
+++ b/ferum_customs/hooks.py
@@ -31,9 +31,10 @@ fixtures = [
     "custom_docperm.json",
     "workflow_service_request.json",
     "portal_menu_item.json",
-    "notification.json",
     "role.json",
+    "notification.json",
     "users.json",
+    "customer.json",
 ]
 
 try:


### PR DESCRIPTION
## Summary
- add DocType fixtures for service request, object and project
- adjust fixture order in hooks

## Testing
- `pre-commit run --all-files` *(fails: frappe.exceptions.IncorrectSitePath)*
- `pytest -q` *(fails: IncorrectSitePath)*

------
https://chatgpt.com/codex/tasks/task_e_6847dc394a788328b07dad8cba1537f7