### PR TITLE
Add DocType fixtures

### DIFF
--- a/ferum_customs/fixtures/service_object.json
+++ b/ferum_customs/fixtures/service_object.json
@@ -1,0 +1,50 @@
+[
+{
+  "doctype": "DocType",
+  "custom": 1,
+  "name": "Service Object",
+  "module": "Ferum Customs",
+  "engine": "InnoDB",
+  "track_changes": 1,
+  "title_field": "object_name",
+  "fields": [
+    {
+      "fieldname": "object_name",
+      "label": "Название объекта",
+      "fieldtype": "Data",
+      "reqd": 1,
+      "in_list_view": 1,
+      "unique": 1
+    },
+    {
+      "fieldname": "customer",
+      "label": "Клиент",
+      "fieldtype": "Link",
+      "options": "Customer",
+      "in_list_view": 1
+    },
+    {
+      "fieldname": "location",
+      "label": "Расположение",
+      "fieldtype": "Data"
+    },
+    {
+      "fieldname": "description",
+      "label": "Описание",
+      "fieldtype": "Text"
+    },
+    {
+      "fieldname": "status",
+      "label": "Статус",
+      "fieldtype": "Select",
+      "options": "Active\nInactive\nUnder Maintenance",
+      "default": "Active",
+      "in_list_view": 1
+    }
+  ],
+  "permissions": [
+    { "role": "Проектный менеджер", "read": 1, "write": 1, "create": 1, "delete": 1 },
+    { "role": "Инженер", "read": 1 }
+  ]
+}
+]

--- a/ferum_customs/fixtures/service_project.json
+++ b/ferum_customs/fixtures/service_project.json
@@ -1,0 +1,30 @@
+[
+{
+  "doctype": "DocType",
+  "custom": 1,
+  "name": "Service Project",
+  "module": "Ferum Customs",
+  "engine": "InnoDB",
+  "track_changes": 1,
+  "title_field": "project_name",
+  "fields": [
+    {
+      "fieldname": "project_name",
+      "label": "Название проекта",
+      "fieldtype": "Data",
+      "reqd": 1,
+      "in_list_view": 1,
+      "unique": 1
+    },
+    {
+      "fieldname": "customer",
+      "label": "Клиент",
+      "fieldtype": "Link",
+      "options": "Customer",
+      "in_list_view": 1
+    },
+    { "fieldname": "start_date", "label": "Дата начала", "fieldtype": "Date" },
+    { "fieldname": "end_date", "label": "Дата окончания", "fieldtype": "Date" }
+  ]
+}
+]

--- a/ferum_customs/fixtures/service_request.json
+++ b/ferum_customs/fixtures/service_request.json
@@ -1,0 +1,50 @@
+[
+{
+  "doctype": "DocType",
+  "custom": 1,
+  "name": "Service Request",
+  "module": "Ferum Customs",
+  "engine": "InnoDB",
+  "is_submittable": 1,
+  "naming_series": "SR-.YYYY.-.#####",
+  "title_field": "subject",
+  "workflow_name": "Service Request Workflow",
+  "track_changes": 1,
+  "track_seen": 1,
+  "track_views": 1,
+  "allow_rename": 1,
+  "fields": [
+    {
+      "fieldname": "request_datetime",
+      "label": "Дата и время заявки",
+      "fieldtype": "Datetime",
+      "default": "Now",
+      "read_only": 1,
+      "in_list_view": 1
+    },
+    {
+      "fieldname": "subject",
+      "label": "Тема",
+      "fieldtype": "Data",
+      "reqd": 1,
+      "in_list_view": 1
+    },
+    {
+      "fieldname": "status",
+      "label": "Статус",
+      "fieldtype": "Data",
+      "read_only": 1,
+      "in_list_view": 1,
+      "no_copy": 1
+    },
+    {
+      "fieldname": "duration_hours",
+      "label": "Длительность (часы)",
+      "fieldtype": "Float",
+      "precision": 2,
+      "read_only": 1,
+      "no_copy": 1
+    }
+  ]
+}
+]

--- a/ferum_customs/hooks.py
+++ b/ferum_customs/hooks.py
@@ -15,17 +15,20 @@ get_notification_config = (
 
 # ── порядок фикстур: сначала DocType, затем поля/права, затем данные ──
 fixtures = [
+    "service_request.json",
+    "service_object.json",
+    "service_project.json",
     "custom_fields.json",
     "custom_docperm.json",
     "workflow_service_request.json",
     "portal_menu_item.json",
-    "notification.json",
     "role.json",
+    "notification.json",
     "users.json",
     "customer.json",
 ]
 
-try:                              # dev-hooks (если есть)
-    from .dev_hooks import *      # noqa
+try:  # dev-hooks (если есть)
+    from .dev_hooks import *  # noqa
 except ImportError:
     pass


### PR DESCRIPTION
## Summary
- add full DocType exports for Service Request/Object/Project
- include new fixtures in hooks

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath errors)*
- `pytest` *(fails: IncorrectSitePath errors)*

------
https://chatgpt.com/codex/tasks/task_e_684868219b9883288eca6da2f57ea781