### PR TITLE
Add Audit Log DocType

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,5 +5,5 @@ ruff
 pytest
 mypy
 pre-commit
-requests==2.32.4
+requests==2.31.0
 click==8.1.7

--- a/ferum_customs/doctype/audit_log/audit_log.json
+++ b/ferum_customs/doctype/audit_log/audit_log.json
@@ -1,0 +1,14 @@
+{
+  "doctype": "DocType",
+  "custom": 1,
+  "name": "Audit Log",
+  "module": "Ferum Customs",
+  "track_changes": 1,
+  "fields": [
+    {"fieldname": "user", "label": "User", "fieldtype": "Link", "options": "User", "reqd": 1, "in_list_view": 1},
+    {"fieldname": "timestamp", "label": "Timestamp", "fieldtype": "Datetime", "default": "Now", "in_list_view": 1},
+    {"fieldname": "action", "label": "Action", "fieldtype": "Data", "reqd": 1, "in_list_view": 1},
+    {"fieldname": "reference_doctype", "label": "Reference Doctype", "fieldtype": "Link", "options": "DocType", "in_list_view": 1},
+    {"fieldname": "reference_name", "label": "Reference Name", "fieldtype": "Data", "in_list_view": 1}
+  ]
+}

--- a/ferum_customs/doctype/audit_log/audit_log.py
+++ b/ferum_customs/doctype/audit_log/audit_log.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from frappe.model.document import Document
+
+
+class AuditLog(Document):
+    """Simple audit log record."""
+
+    pass

--- a/ferum_customs/doctype/audit_log/test_audit_log.py
+++ b/ferum_customs/doctype/audit_log/test_audit_log.py
@@ -1,0 +1,16 @@
+import pytest
+
+try:
+    import frappe
+    from frappe.tests.utils import FrappeTestCase
+except Exception:  # pragma: no cover
+    pytest.skip("frappe not available", allow_module_level=True)
+
+
+class TestAuditLog(FrappeTestCase):
+    def test_basic(self, frappe_site):
+        doc = frappe.new_doc("Audit Log")
+        doc.user = "Administrator"
+        doc.action = "login"
+        doc.insert()
+        self.assertIsNotNone(doc.name)

--- a/ferum_customs/fixtures/audit_log.json
+++ b/ferum_customs/fixtures/audit_log.json
@@ -1,0 +1,3 @@
+[
+  {"doctype": "DocType", "name": "Audit Log"}
+]

--- a/ferum_customs/hooks.py
+++ b/ferum_customs/hooks.py
@@ -20,6 +20,7 @@ fixtures = [
     "service_project.json",
     "custom_fields.json",
     "custom_docperm.json",
+    "audit_log.json",
     "workflow_service_request.json",
     "portal_menu_item.json",
     "role.json",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 black
 ruff
 pytest
-requests==2.32.4
+requests==2.31.0
 click==8.1.7
 frappe


### PR DESCRIPTION
## Summary
- add new Audit Log DocType and tests
- include Audit Log fixture in hooks
- pin requests 2.31 compatible with Frappe

## Testing
- `pre-commit run --all-files` *(with SKIP=pytest)*
- `pytest` *(fails: IncorrectSitePath: 404 Not Found: test_site does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6851692ddc6883289bf7954600efda7e