### PR TITLE
Improve Docker setup and CI waiting logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Run pytest
         run: |
           echo "Waiting for Frappe site to become available..."
-          timeout=300 # Таймаут 5 минут
+          timeout=600 # Увеличенный таймаут 10 минут
           start_time=$(date +%s)
           # Имя хоста и порт должны соответствовать настройкам в docker-compose.yml
           SITE_HOST="http://localhost:8000"
@@ -102,6 +102,7 @@ jobs:
             elapsed=$((current_time - start_time))
             if [ $elapsed -ge $timeout ]; then
               echo "::error::Timeout: Site did not become ready in ${timeout} seconds."
+              docker compose logs mariadb
               docker compose logs frappe # Выводим логи для отладки
               exit 1
             fi

--- a/bench_setup.sh
+++ b/bench_setup.sh
@@ -15,9 +15,20 @@ init_bench() {
 
 create_site() {
     if ! bench --site "$SITE_NAME" ls >/dev/null 2>&1; then
+        DB_HOST="${DB_HOST:-mariadb}"
+        DB_PORT="${DB_PORT:-3306}"
+        DB_ROOT_USER="${DB_ROOT_USER:-root}"
+        DB_ROOT_PASSWORD="${DB_ROOT_PASSWORD:-${MYSQL_ROOT_PASSWORD:-root}}"
+        until mysqladmin ping -h"$DB_HOST" --silent; do
+            echo "\u23F3 Waiting for MariaDB..."
+            sleep 5
+        done
         bench new-site "$SITE_NAME" \
             --admin-password "${ADMIN_PASSWORD:-admin}" \
-            --mariadb-root-password "${MYSQL_ROOT_PASSWORD:-root}" \
+            --db-host "$DB_HOST" \
+            --db-port "$DB_PORT" \
+            --mariadb-root-username "$DB_ROOT_USER" \
+            --mariadb-root-password "$DB_ROOT_PASSWORD" \
             --no-mariadb-socket
     fi
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,24 @@
 version: '3'
 
-services: 
+services:
   mariadb:
     image: mariadb:10.6
     environment:
       MYSQL_ROOT_PASSWORD: root
     volumes:
       - mariadb:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - frappe_net
 
   redis:
     image: redis:latest
+    networks:
+      - frappe_net
 
   frappe:
     build: .
@@ -17,16 +26,27 @@ services:
     ports:
       - "8000:8000"
     depends_on:
-      - mariadb
-      - redis
+      mariadb:
+        condition: service_healthy
+      redis:
+        condition: service_started
     environment:
       - SITE_NAME=test_site
       - ADMIN_PWD=admin
       - DB_ROOT_PWD=root
+      - DB_HOST=mariadb
+      - DB_PORT=3306
+      - DB_ROOT_USER=root
+      - DB_ROOT_PASSWORD=root
     volumes:
       - sites_volume:/home/frappe/frappe-bench/sites
+    networks:
+      - frappe_net
 
 volumes:
   mariadb:
   redis:
   sites_volume:
+
+networks:
+  frappe_net:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,6 +5,10 @@ BENCH_FOLDER="${BENCH_FOLDER:-frappe-bench}"
 SITE_NAME="${SITE_NAME:-test_site}"
 ADMIN_PWD="${ADMIN_PWD:-admin}"
 DB_ROOT_PWD="${DB_ROOT_PWD:-""}"
+DB_HOST="${DB_HOST:-mariadb}"
+DB_PORT="${DB_PORT:-3306}"
+DB_ROOT_USER="${DB_ROOT_USER:-root}"
+DB_ROOT_PASSWORD="${DB_ROOT_PASSWORD:-$DB_ROOT_PWD}"
 
 if [ ! -d "$BENCH_FOLDER" ]; then
     /bootstrap.sh
@@ -14,9 +18,16 @@ cd "$BENCH_FOLDER"
 
 if [ ! -f "/home/frappe/frappe-bench/sites/${SITE_NAME}/site_config.json" ]; then
     echo ">> Creating Frappe site ${SITE_NAME}"
+    until mysqladmin ping -h"$DB_HOST" --silent; do
+        echo "\u23F3 Waiting for MariaDB..."
+        sleep 5
+    done
     bench new-site "$SITE_NAME" \
          --admin-password "$ADMIN_PWD" \
-         --mariadb-root-password "$DB_ROOT_PWD" \
+         --db-host "$DB_HOST" \
+         --db-port "$DB_PORT" \
+         --mariadb-root-username "$DB_ROOT_USER" \
+         --mariadb-root-password "$DB_ROOT_PASSWORD" \
          --install-app erpnext
 fi
 


### PR DESCRIPTION
## Summary
- add healthcheck for mariadb
- wait for database in entrypoint and bench setup scripts
- configure frappe to depend on healthy mariadb
- expose DB connection variables in compose file
- increase CI wait timeout and show mariadb logs on failure

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath - test_site does not exist)*
- `pytest -q` *(fails: IncorrectSitePath errors)*

------
https://chatgpt.com/codex/tasks/task_e_68517a2716908328b3868b6b07186b1a