### PR TITLE
Add ERPNext install steps to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ENV PATH=$PATH:/home/frappe/.local/bin
 RUN bench --version
 RUN yarn config set registry https://registry.npmjs.org \
  && yarn config set network-timeout 600000
-RUN bench init frappe-bench --frappe-branch version-15 --skip-assets
+RUN bench init frappe-bench --frappe-branch version-15 --skip-assets && \
+    cd frappe-bench && \
+    bench get-app erpnext --branch version-15 && \
+    bench --site test_site install-app erpnext
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- fetch and install ERPNext during Docker build

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath: 404 Not Found: test_site does not exist)*
- `pytest` *(fails: IncorrectSitePath: 404 Not Found: test_site does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685184313bd483289ad613fd55b6c61b