### PR TITLE
Fix Docker setup and entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ RUN yarn config set registry https://registry.npmjs.org \
  && yarn config set network-timeout 600000
 RUN bench init frappe-bench --frappe-branch version-15 --skip-assets && \
     cd frappe-bench && \
-    bench get-app erpnext --branch version-15 && \
-    bench --site test_site install-app erpnext
+    bench get-app erpnext --branch version-15
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
## Summary
- keep ERPNext install in entrypoint instead of Dockerfile
- simplify entrypoint for dev/testing

## Testing
- `pre-commit run --files Dockerfile entrypoint.sh` *(fails: pytest errors due to missing site)*
- `pytest -q` *(fails: IncorrectSitePath errors)*

------
https://chatgpt.com/codex/tasks/task_e_685187b356208328a5ba511f2202c83d