### PR TITLE
Add cron backup example

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ export OPENAI_API_KEY="<ваш-ключ>"
 Scripts in the `scripts` directory simplify creation and restoration of backups.
 Run `./scripts/backup.sh` to create an archive and `./scripts/restore.sh` with a
 backup file to restore. Systemd unit files inside `scripts/systemd` can automate
-daily backups. Detailed instructions are available in
+daily backups. A cron job example is available in `scripts/cron` for systems
+where systemd is not used. Detailed instructions are available in
 [docs/backup.md](docs/backup.md).
 
 После настройки запустите `codex` в каталоге проекта. Подробности в [docs/CODEX_SETUP.md](docs/CODEX_SETUP.md).

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -33,3 +33,14 @@ sudo systemctl enable --now ferum_backup.timer
 ```
 
 The timer runs `ferum_backup.service` daily and keeps archives for seven days.
+
+## Automation via cron
+
+To schedule backups with cron copy the provided job file:
+
+```bash
+sudo cp scripts/cron/ferum_backup /etc/cron.d/
+sudo systemctl reload cron
+```
+
+The cron job runs `backup.sh` every day at 02:00.

--- a/scripts/cron/ferum_backup
+++ b/scripts/cron/ferum_backup
@@ -1,0 +1,3 @@
+# Example cron job for daily Ferum Customs backups
+# Adjust the path to backup.sh if the repository is elsewhere
+0 2 * * * root /workspace/ferum_customs_release_final-main/scripts/backup.sh


### PR DESCRIPTION
## Summary
- document cron backup setup
- mention cron example in README
- provide `scripts/cron/ferum_backup`

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath)*
- `pytest` *(fails: IncorrectSitePath)*

------
https://chatgpt.com/codex/tasks/task_e_6851911fdf6c83289a1a3874dc7229e4