### PR TITLE
Add redis install step and cache for Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildkit-
 
+      - name: Upgrade Docker Compose (>= 2.10)
+        run: |
+          sudo curl -L https://github.com/docker/compose/releases/download/v2.23.3/docker-compose-linux-x86_64 \
+          -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+          docker compose version   # вывод версии для контроля
+
       # Шаг 2: Сборка и запуск Docker-стека в фоновом режиме
       - name: Build and start Frappe Stack
         run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d --build --progress plain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,9 +83,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Кэш Docker layer'ов для ускорения сборки
+      - name: Restore Docker build cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/buildkit
+          key: ${{ runner.os }}-buildkit-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildkit-
+
       # Шаг 2: Сборка и запуск Docker-стека в фоновом режиме
       - name: Build and start Frappe Stack
-        run: docker compose -f docker-compose.yml up -d --build
+        run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d --build --progress plain
 
 
       # --- Tests ----------------------------------------------------------
@@ -140,3 +149,10 @@ jobs:
       - name: Stop Frappe Stack
         if: always() # Выполняется всегда
         run: docker compose down -v
+
+      - name: Save Docker build cache
+        if: always()
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/buildkit
+          key: ${{ runner.os }}-buildkit-${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update \
     && apt-get install -y git mariadb-client nodejs npm curl cron \
     && npm install -g yarn@1.22.19 \
     && useradd -ms /bin/bash frappe
+# Install Redis before bench init
+RUN apt-get update && apt-get install -y redis-server=5:7.0.*
 RUN pip install --no-cache-dir pytest pytest-cov
 
 COPY bench_setup.sh /bench_setup.sh

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 "$SCRIPT_DIR/bench_setup.sh" tests
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # Execute bench setup with provided argument or default to dev
 if [ $# -eq 0 ]; then


### PR DESCRIPTION
## Summary
- pin redis to 7.0 for Frappe compatibility
- stop scripts on any unset variable or pipe failure
- cache Docker build layers in CI

## Testing
- `pre-commit run --files Dockerfile bootstrap.sh entrypoint.sh .github/workflows/ci.yml`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685237b75f00832897993f515e821455