### PR TITLE
Fix service request notifications

### DIFF
--- a/ferum_customs/custom_logic/service_request_hooks.py
+++ b/ferum_customs/custom_logic/service_request_hooks.py
@@ -131,6 +131,14 @@ def _notify_project_manager(doc: "ServiceRequest") -> None:
             distinct=True,
         )
 
+        customer_email = doc.get("customer_email")
+        if customer_email:
+            recipients.append(customer_email)
+        else:
+            frappe.logger(__name__).warning(
+                f"Service Request '{doc.name}' has no customer_email field set"
+            )
+
         if not recipients:
             frappe.logger(__name__).warning(
                 _("Получатели с ролью '{0}' не найдены для уведомления.").format(

--- a/ferum_customs/doctype/service_request/service_request.json
+++ b/ferum_customs/doctype/service_request/service_request.json
@@ -29,6 +29,13 @@
       "in_list_view": 1
     },
     {
+      "fieldname": "customer_email",
+      "label": "Email клиента",
+      "fieldtype": "Data",
+      "options": "Email",
+      "in_list_view": 1
+    },
+    {
       "fieldname": "status",
       "label": "Статус",
       "fieldtype": "Data",

--- a/ferum_customs/fixtures/service_request.json
+++ b/ferum_customs/fixtures/service_request.json
@@ -30,6 +30,13 @@
       "in_list_view": 1
     },
     {
+      "fieldname": "customer_email",
+      "label": "Email клиента",
+      "fieldtype": "Data",
+      "options": "Email",
+      "in_list_view": 1
+    },
+    {
       "fieldname": "status",
       "label": "Статус",
       "fieldtype": "Data",

--- a/ferum_customs/tests/test_permissions.py
+++ b/ferum_customs/tests/test_permissions.py
@@ -1,0 +1,30 @@
+import pytest
+
+try:
+    import frappe
+    from frappe.tests.utils import FrappeTestCase
+except Exception:  # pragma: no cover
+    pytest.skip("frappe not available", allow_module_level=True)
+
+
+class TestPermissions(FrappeTestCase):
+    def test_sales_user_cannot_cancel(self, frappe_site):
+        sr = frappe.new_doc("Service Request")
+        sr.subject = "Perm Test"
+        sr.status = "Открыта"
+        sr.insert(ignore_permissions=True)
+        sr.submit()
+
+        user = frappe.get_doc({
+            "doctype": "User",
+            "email": "sales@example.com",
+            "first_name": "Sales",
+            "roles": [{"role": "Sales User"}]
+        })
+        user.insert(ignore_permissions=True)
+
+        frappe.set_user(user.name)
+        with pytest.raises(frappe.PermissionError):
+            sr.cancel()
+
+        frappe.set_user("Administrator")


### PR DESCRIPTION
## Summary
- add `customer_email` field
- send notifications to `customer_email` when closing a service request
- ensure missing email is logged
- test permissions for cancelling service request

## Testing
- `pre-commit run --all-files` *(fails: IncorrectSitePath errors)*
- `pytest` *(fails: IncorrectSitePath errors)*

------
https://chatgpt.com/codex/tasks/task_e_68526bf7f89083288d8c532a6acd417a