### PR TITLE
Fix style issues and enforce line length

### DIFF
--- a/ferum_customs/tests/test_permissions.py
+++ b/ferum_customs/tests/test_permissions.py
@@ -15,12 +15,14 @@ class TestPermissions(FrappeTestCase):
         sr.insert(ignore_permissions=True)
         sr.submit()
 
-        user = frappe.get_doc({
-            "doctype": "User",
-            "email": "sales@example.com",
-            "first_name": "Sales",
-            "roles": [{"role": "Sales User"}]
-        })
+        user = frappe.get_doc(
+            {
+                "doctype": "User",
+                "email": "sales@example.com",
+                "first_name": "Sales",
+                "roles": [{"role": "Sales User"}],
+            }
+        )
         user.insert(ignore_permissions=True)
 
         frappe.set_user(user.name)


### PR DESCRIPTION
## Summary
- format tests using Black
- ensure Black and Ruff line-length settings match
- install pre-commit hook for local usage

## Testing
- `pre-commit run --files ferum_customs/tests/test_permissions.py` *(fails: IncorrectSitePath errors)*


------
https://chatgpt.com/codex/tasks/task_e_68526f8cf3648328929e2beaa20a2dcf