### PR TITLE
Use SITE_NAME env for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
     needs: lint
     runs-on: ubuntu-22.04
     timeout-minutes: 30
+    env:
+      SITE_NAME: ci_site
 
     steps:
       # Шаг 1: Клонирование кода
@@ -136,11 +138,11 @@ jobs:
           done
 
       # Шаг 4: Запуск тестов pytest внутри работающего контейнера
-      # Имя сервиса 'frappe' и имя сайта 'test_site' взяты из docker-compose.yml
+      # Имя сервиса 'frappe' и имя сайта берутся из docker-compose.yml
       - name: Run tests inside container
         run: >
           docker compose exec -T frappe
-          bench --site test_site run-tests --app ferum_customs
+          bench --site "$SITE_NAME" run-tests --app ferum_customs
 
       # Шаг 5 (опционально): Загрузка артефактов (отчетов о тестировании)
       # Если ваши тесты генерируют отчеты (например, в формате JUnit),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       redis:
         condition: service_started
     environment:
-      - SITE_NAME=test_site
+      - SITE_NAME=${SITE_NAME:-test_site}
       - ADMIN_PASSWORD=admin
       - DB_ROOT_PASSWORD=root
       - DB_HOST=mariadb

--- a/ferum_customs/tests/conftest.py
+++ b/ferum_customs/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import sys
 
+import frappe
 import pytest
 
 # Ensure package root is importable before tests are collected
@@ -20,3 +21,15 @@ def setup_sys_path() -> None:
 def site_host() -> str:
     """Provides base URL for frappe site."""
     return os.getenv("SITE_HOST", "http://localhost:8000")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def init_frappe_site():
+    """Initialize and connect to the Frappe site for the test session."""
+    site = os.environ.get("SITE_NAME") or getattr(frappe.local, "site", None)
+    if not site:
+        pytest.skip("No Frappe site available")
+    frappe.init(site)
+    frappe.connect()
+    yield
+    frappe.destroy()

--- a/ferum_customs/tests/test_basic.py
+++ b/ferum_customs/tests/test_basic.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 try:
@@ -8,5 +10,7 @@ except Exception:  # pragma: no cover - frappe not installed
 
 
 class TestTestBasic(FrappeTestCase):
+    TEST_SITE = os.environ.get("SITE_NAME", getattr(frappe.local, "site", None))
+
     def test_basic(self, frappe_site):
         self.assertTrue(True)

--- a/ferum_customs/tests/test_create_invoice.py
+++ b/ferum_customs/tests/test_create_invoice.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 pytest.importorskip("frappe")
@@ -22,6 +24,8 @@ class DummyDoc(SimpleNamespace):
 
 
 class TestCreateInvoice(FrappeTestCase):
+    TEST_SITE = os.environ.get("SITE_NAME", getattr(frappe.local, "site", None))
+
     def test_create_invoice_success(self, monkeypatch, frappe_site):
         sr = DummyDoc(
             name="SR-1",

--- a/ferum_customs/tests/test_permissions.py
+++ b/ferum_customs/tests/test_permissions.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 try:
@@ -8,6 +10,8 @@ except Exception:  # pragma: no cover
 
 
 class TestPermissions(FrappeTestCase):
+    TEST_SITE = os.environ.get("SITE_NAME", getattr(frappe.local, "site", None))
+
     def test_sales_user_cannot_cancel(self, frappe_site):
         sr = frappe.new_doc("Service Request")
         sr.subject = "Perm Test"

--- a/ferum_customs/tests/test_service_object_hooks.py
+++ b/ferum_customs/tests/test_service_object_hooks.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 try:
@@ -19,6 +21,8 @@ class DummyDoc:
 
 
 class TestServiceObjectHooks(FrappeTestCase):
+    TEST_SITE = os.environ.get("SITE_NAME", getattr(frappe.local, "site", None))
+
     def test_validate_unique(self, monkeypatch, frappe_site):
         doc = DummyDoc("SN-1")
         monkeypatch.setattr(frappe.db, "exists", lambda *args, **kwargs: None)

--- a/ferum_customs/tests/test_service_report_hooks.py
+++ b/ferum_customs/tests/test_service_report_hooks.py
@@ -1,3 +1,4 @@
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -18,6 +19,8 @@ class DummyDoc(SimpleNamespace):
 
 
 class TestServiceReportHooks(FrappeTestCase):
+    TEST_SITE = os.environ.get("SITE_NAME", getattr(frappe.local, "site", None))
+
     def test_validate_ok(self, monkeypatch, frappe_site):
         doc = DummyDoc(service_request="REQ-1", name="SR-1")
         monkeypatch.setattr(frappe.db, "exists", lambda *a, **k: True)

--- a/ferum_customs/tests/test_service_request_hooks.py
+++ b/ferum_customs/tests/test_service_request_hooks.py
@@ -1,3 +1,4 @@
+import os
 from types import SimpleNamespace
 
 import pytest
@@ -17,6 +18,8 @@ class DummyEntry(SimpleNamespace):
 
 
 class TestServiceRequestHooks(FrappeTestCase):
+    TEST_SITE = os.environ.get("SITE_NAME", getattr(frappe.local, "site", None))
+
     def test_get_engineers(self, monkeypatch, frappe_site):
         doc = SimpleNamespace(
             assigned_engineers=[

--- a/ferum_customs/tests/test_utils.py
+++ b/ferum_customs/tests/test_utils.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 pytest.importorskip("frappe")
@@ -15,6 +17,8 @@ class DummyEntry(SimpleNamespace):
 
 
 class TestUtils(FrappeTestCase):
+    TEST_SITE = os.environ.get("SITE_NAME", getattr(frappe.local, "site", None))
+
     def test_get_engineers_for_object(self, monkeypatch, frappe_site):
         doc = SimpleNamespace(
             assigned_engineers=[


### PR DESCRIPTION
## Summary
- auto-connect to specified Frappe site in test fixture
- parametrize test classes with SITE_NAME env variable
- allow site name override in docker compose
- inject SITE_NAME into CI workflow

## Testing
- `pre-commit run --all-files` *(fails: pytest reports missing Frappe site)*
- `pytest -q` *(fails: 40 errors, site does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_685277174e0083289c6840acb25b4ead