### PR TITLE
Drop heavy deps from pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,17 @@ jobs:
       - name: Build and start Frappe Stack
         run: DOCKER_BUILDKIT=1 docker compose -f docker-compose.yml up -d --build
 
+      - name: Create Frappe test site
+        run: |
+          docker compose exec -T frappe bench new-site $SITE_NAME \
+            --admin-password $ADMIN_PASSWORD \
+            --no-mariadb-socket \
+            --install-app erpnext \
+            --install-app ferum_customs
+        env:
+          SITE_NAME: test_site
+          ADMIN_PASSWORD: admin
+
 
       # --- Tests ----------------------------------------------------------
       - name: Run pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,14 +17,3 @@ repos:
       - id: mypy
         args: [--config-file=pyproject.toml]
         additional_dependencies: [types-requests]
-  - repo: local
-    hooks:
-      - id: pytest
-        name: pytest
-        entry: pytest
-        language: python
-        pass_filenames: false
-        additional_dependencies:
-          - pytest>=8
-          - frappe-framework==15.19.0
-          - bench==5.20.0

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,5 +11,3 @@ requests==2.31.0
 click==8.1.7
 qrcode
 zxcvbn-python
-frappe-framework==15.19.0
-bench==5.20.0

--- a/ferum_customs/tests/conftest.py
+++ b/ferum_customs/tests/conftest.py
@@ -1,10 +1,11 @@
 import os
-import sys
-
-import frappe
-import pytest
 import pathlib
 import subprocess
+import sys
+
+import pytest
+
+frappe = pytest.importorskip("frappe")
 
 # Ensure package root is importable before tests are collected
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
@@ -32,31 +33,37 @@ def ensure_test_site(tmp_path_factory):
     sites_dir = bench_path / "sites"
 
     if not (sites_dir / site).exists():
-        subprocess.check_call([
-            "bench",
-            "init",
-            str(bench_path),
-            "--skip-redis-config-generation",
-        ])
-        subprocess.check_call([
-            "bench",
-            "--site",
-            site,
-            "new-site",
-            "--db-type",
-            "sqlite",
-            "--admin-password",
-            "admin",
-            "--db-name",
-            f"{site}.db",
-        ])
-        subprocess.check_call([
-            "bench",
-            "--site",
-            site,
-            "install-app",
-            "ferum_customs",
-        ])
+        subprocess.check_call(
+            [
+                "bench",
+                "init",
+                str(bench_path),
+                "--skip-redis-config-generation",
+            ]
+        )
+        subprocess.check_call(
+            [
+                "bench",
+                "--site",
+                site,
+                "new-site",
+                "--db-type",
+                "sqlite",
+                "--admin-password",
+                "admin",
+                "--db-name",
+                f"{site}.db",
+            ]
+        )
+        subprocess.check_call(
+            [
+                "bench",
+                "--site",
+                site,
+                "install-app",
+                "ferum_customs",
+            ]
+        )
 
     frappe.init(site)
     frappe.connect()


### PR DESCRIPTION
## Summary
- remove bench/frappe deps from dev requirements
- simplify pre-commit config by dropping pytest hook
- create Frappe site in CI before running tests
- skip tests when Frappe is absent

## Testing
- `pre-commit run --all-files`
- `pytest` *(fails: ModuleNotFoundError: bench not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6852950ad1748328afd48a94855ffc8f