### PR TITLE
Update test setup to run under dedicated user

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SITE_NAME: test_site
-      SITES_PATH: .bench/sites
       ADMIN_PASSWORD: admin
     steps:
       - name: Checkout repository
@@ -23,11 +22,9 @@ jobs:
       - name: Install dependencies
         run: pip install -r dev-requirements.txt
       - name: Prepare Frappe test site
-        run: |
-          bash scripts/setup_test_site.sh
+        run: bash scripts/setup_test_site.sh
         env:
-          SITE_NAME: ${{ env.SITE_NAME }}
-          SITES_PATH: ${{ env.SITES_PATH }}
-          ADMIN_PASSWORD: ${{ env.ADMIN_PASSWORD }}
+          SITE_NAME: test_site
+          ADMIN_PASSWORD: admin
       - name: Run pytest
         run: pytest -q

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,9 @@ COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /bootstrap.sh /bench_setup.sh /entrypoint.sh
 
 USER frappe
+ENV PATH="$HOME/.local/bin:$PATH"
+RUN pip install --no-cache-dir frappe-bench==5.20.0
 WORKDIR /home/frappe
-
-RUN pip install --no-cache-dir --user frappe-bench
-ENV PATH=$PATH:/home/frappe/.local/bin
 RUN bench --version
 RUN yarn config set registry https://registry.npmjs.org \
  && yarn config set network-timeout 600000
@@ -38,5 +37,7 @@ RUN cd frappe-bench && \
         --no-mariadb-socket \
         --install-app erpnext \
         --install-app ferum_customs
+
+WORKDIR /workspace
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,9 +30,9 @@ services:
       redis:
         condition: service_started
     environment:
-      SITE_NAME: ${SITE_NAME:-test_site}
-      SITES_PATH: .bench/sites
-      ADMIN_PASSWORD: ${ADMIN_PASSWORD:-admin}
+      SITE_NAME: test_site
+      ADMIN_PASSWORD: admin
+      SITES_PATH: /home/frappe/ci-bench/sites
       DB_ROOT_PASSWORD: root
       DB_HOST: mariadb
       DB_PORT: 3306

--- a/ferum_customs/tests/conftest.py
+++ b/ferum_customs/tests/conftest.py
@@ -2,30 +2,23 @@ import os
 import pathlib
 import sys
 
+import frappe
 import pytest
-
-frappe = pytest.importorskip("frappe")
 
 # Ensure package root is importable before tests are collected
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
-SITE = os.environ.get("SITE_NAME", "test_site")
-SITES_PATH = pathlib.Path(os.environ.get("SITES_PATH", ".bench/sites"))
+SITE = os.environ["SITE_NAME"]
+SITE_PATH = pathlib.Path("test_site").resolve()
 
 
 @pytest.fixture(scope="session", autouse=True)
-def connect_frappe():
-    # если Frappe уже подключён сайтом из FrappeTestCase, ничего не делаем
-    if getattr(frappe.local, "site", None) == SITE:
-        return
-
-    site_path = SITES_PATH / SITE
-    if not site_path.exists():
-        pytest.skip(f"Site {site_path} not found – run setup_test_site.sh")
-
-    frappe.init(site=SITE, sites_path=str(SITES_PATH))
+def _connect():
+    if not SITE_PATH.exists():
+        pytest.fail(f"{SITE_PATH} not found – site preparation step failed")
+    frappe.init(site=SITE, sites_path=str(SITE_PATH.parent))
     frappe.connect()
     yield
     frappe.destroy()

--- a/scripts/setup_test_site.sh
+++ b/scripts/setup_test_site.sh
@@ -1,36 +1,24 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-export CI=${CI:-true}
+set -eo pipefail
 
 SITE_NAME=${SITE_NAME:-test_site}
 ADMIN_PWD=${ADMIN_PASSWORD:-admin}
+BENCH_DIR="$HOME/ci-bench"
 
-# Создать bench в каталоге .bench, если ещё нет
-if [ ! -d ".bench" ]; then
-  bench init .bench --skip-assets --skip-redis-config-generation
+if [ ! -d "$BENCH_DIR" ]; then
+  bench init "$BENCH_DIR" --skip-redis-config-generation --no-switch-bench
 fi
 
-cd .bench
+cd "$BENCH_DIR"
 
-# Создать сайт ― пропускаем, если уже создан
 if [ ! -d "sites/$SITE_NAME" ]; then
   bench new-site "$SITE_NAME" \
         --admin-password "$ADMIN_PWD" \
         --db-type sqlite \
         --no-mariadb-socket
+  bench --site "$SITE_NAME" install-app ferum_customs
 fi
 
-# Установить ваши приложения (и ERPNext при необходимости)
-bench --site "$SITE_NAME" install-app ferum_customs
-# bench --site "$SITE_NAME" install-app erpnext   # если нужно
-
-# Создать символическую ссылку ../test_site → .bench/sites/test_site
-SITE_PATH="sites/$SITE_NAME"
-BENCH_DIR=".bench"
-if [ ! -e "../test_site" ]; then
-  ln -s "$SITE_PATH" ../test_site
-fi
-echo "✅ Symlink ../test_site → $BENCH_DIR/$SITE_PATH готов"
-
-echo "✅ Site $SITE_NAME ready"
+cd "$OLDPWD"
+ln -snf "$BENCH_DIR/sites/$SITE_NAME" "./test_site"
+echo "✅ Site $SITE_NAME готов и смонтирован как ./test_site"


### PR DESCRIPTION
## Summary
- switch Docker builds to use the `frappe` user
- update helper script to create bench inside the user's home
- adjust docker-compose and CI workflow variables
- remove skip logic from the test fixture

## Testing
- `pre-commit run --all-files`
- `pytest -q` *(fails: KeyError: 'SITE_NAME')*

------
https://chatgpt.com/codex/tasks/task_e_6852a65a7fb08328b2b6d9e580655dda